### PR TITLE
Revoke apple token usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>3.8.3</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <renarde.version>3.0.9</renarde.version>
+    <renarde.version>3.0.12-SNAPSHOT</renarde.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,7 +29,7 @@ quarkus.oidc.apple.provider=apple
 quarkus.oidc.apple.client-id=SECRET
 quarkus.oidc.apple.credentials.jwt.key-file=Apple-key-dev.p8
 # this actually needs to be set for Apple keys, but not the fake dev one
-quarkus.oidc.apple.credentials.jwt.token-key-id=SECRET
+#quarkus.oidc.apple.credentials.jwt.token-key-id=SECRET
 quarkus.oidc.apple.credentials.jwt.issuer=SECRET
 quarkus.oidc.apple.credentials.jwt.subject=SECRET
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,7 +29,7 @@ quarkus.oidc.apple.provider=apple
 quarkus.oidc.apple.client-id=SECRET
 quarkus.oidc.apple.credentials.jwt.key-file=Apple-key-dev.p8
 # this actually needs to be set for Apple keys, but not the fake dev one
-#quarkus.oidc.apple.credentials.jwt.token-key-id=SECRET
+quarkus.oidc.apple.credentials.jwt.token-key-id=SECRET
 quarkus.oidc.apple.credentials.jwt.issuer=SECRET
 quarkus.oidc.apple.credentials.jwt.subject=SECRET
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -3,6 +3,7 @@ main.help=Help
 main.about=About
 main.language=Language
 main.logout=Logout
+main.revoke=Revoke
 main.backoffice=Backoffice
 main.todos=Todos
 

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -3,6 +3,7 @@ main.help=Aide
 main.about=À propos
 main.language=Langue
 main.logout=Déconnexion
+main.revoke=Suppression
 main.backoffice=Administration
 main.todos=Tâches
 

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -33,6 +33,9 @@
                       <li class="nav-item"><a class="nav-link" aria-current="page" href="/_renarde/backoffice/index"><i class="bi bi-database"></i>{m:main.backoffice}</a></li>
                     {/if}
                     <li class="nav-item"><a class="nav-link" aria-current="page" href="{uri:RenardeSecurityController.logout()}">{m:main.logout}</a></li>
+                    {#if inject:user.tenantId && inject:user.tenantId is 'apple'}
+                      <li class="nav-item"><a class="nav-link" aria-current="page" href="{uri:RernardeRevokeController.revokeApple()}" >{m:main.revoke}</a></li>
+                    {/if}
                 {/if}
                 <li class="nav-item dropdown">
                   <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -34,7 +34,7 @@
                     {/if}
                     <li class="nav-item"><a class="nav-link" aria-current="page" href="{uri:RenardeSecurityController.logout()}">{m:main.logout}</a></li>
                     {#if inject:user.tenantId && inject:user.tenantId is 'apple'}
-                      <li class="nav-item"><a class="nav-link" aria-current="page" href="{uri:RernardeRevokeController.revokeApple()}" >{m:main.revoke}</a></li>
+                      <li class="nav-item"><a class="nav-link" aria-current="page" href="{uri:RenardeRevokeController.revokeApple()}" >{m:main.revoke}</a></li>
                     {/if}
                 {/if}
                 <li class="nav-item dropdown">


### PR DESCRIPTION
Exemple usage for Apple token revocation.

To try it: 
* enable HTTPS (generate cert and use `quarkus.http.ssl.certificate.key-store-file`propperty)
* create an ngrock account (since valid redirect to localhost is not allowed by Apple)
* create an apple developper account and set application.properties accordingly. See [HERE](https://quarkus.io/guides/security-openid-connect-providers#apple)
* Run in dev mode, run ngrock command
* Login with Apple
* A new button appears on top bar, it will revoke the access and logout the user.

Extra files needed: 
* apple's "P8" file : private key to sign token
* keystore.jks : self-signed cert for HTTPS